### PR TITLE
SetPropertyValue: fix initial value set

### DIFF
--- a/components/SetPropertyValue.coffee
+++ b/components/SetPropertyValue.coffee
@@ -3,7 +3,6 @@ noflo = require 'noflo'
 class SetPropertyValue extends noflo.Component
   constructor: ->
     @property = null
-    @value = null
     @data = []
     @groups = []
     @keep = false


### PR DESCRIPTION
I get the property of my object to be set to null by default, which it shouldn't.
Unattended consequence of 62ae4b848e454b459e2c104223dce96896cb6898
