### PR TITLE
Fix SetPropertyValue value bug

### DIFF
--- a/components/SetPropertyValue.coffee
+++ b/components/SetPropertyValue.coffee
@@ -30,6 +30,6 @@ exports.getComponent = ->
 
     data = input.getData 'in'
     property = input.getData 'property'
-    value = input.get 'value'
-    data[property] = value.data
+    value = input.getData 'value'
+    data[property] = value
     output.sendDone out: data

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noflo-objects",
   "description": "Object Utilities for NoFlo",
-  "version": "0.3.0-beta1",
+  "version": "0.3.0-beta2",
   "keywords": [
     "noflo",
     "objects",
@@ -28,7 +28,7 @@
     "url": "https://github.com/noflo/noflo-objects.git"
   },
   "dependencies": {
-    "noflo": "^0.8.0-beta2",
+    "noflo": "^0.8.0-beta3",
     "underscore": "~1.8.3",
     "owl-deepcopy": "~0.0.6"
   },


### PR DESCRIPTION
`noflo@0.8.0-beta3` fixes `null` as `undefined` bug in `input.getData()`. And this PR uses that to fix a bug in `SetPropertyValue` which set values from bracket IPs instead of data.